### PR TITLE
Generating a link for heading in TOC-enabled mode

### DIFF
--- a/mynt/parsers/markdown/misaka.py
+++ b/mynt/parsers/markdown/misaka.py
@@ -13,9 +13,9 @@ class _Renderer(m.HtmlRenderer):
     _toc_ids = {}
     _toc_patterns = [
         (r'<[^<]+?>', ''),
-        (r'[^a-z0-9_.\s-]', ''),
+        (r'[^\w0-9_.\s-]', ''),
         (r'\s+', '-'),
-        (r'^[^a-z]+', ''),
+        (r'^[^\w]+', ''),
         (r'^$', 'section')
     ]
     
@@ -33,7 +33,7 @@ class _Renderer(m.HtmlRenderer):
             identifier = text.lower()
             
             for pattern, replace in self._toc_patterns:
-                identifier = re.sub(pattern, replace, identifier)
+                identifier = re.sub(pattern, replace, identifier, flags=re.UNICODE)
             
             if identifier in self._toc_ids:
                 self._toc_ids[identifier] += 1

--- a/mynt/parsers/markdown/misaka.py
+++ b/mynt/parsers/markdown/misaka.py
@@ -41,7 +41,7 @@ class _Renderer(m.HtmlRenderer):
             else:
                 self._toc_ids[identifier] = 1
             
-            return '<h{0} id="{1}">{2}</h{0}>'.format(level, identifier, text).encode('utf-8')
+            return '<h{0} id="{1}"><a href="#{1}" title="{2}">{2}</a></h{0}>'.format(level, identifier, text).encode('utf-8')
         else:
             return '<h{0}>{1}</h{0}>'.format(level, text).encode('utf-8')
     


### PR DESCRIPTION
When TOC-mode enabled, there's also a link created inside every header to point to this chapter. Reader can easily copy-paste it.
