### PR TITLE
Support Table of Contents (aka T.O.C.) generation for Posts

### DIFF
--- a/mynt/parsers/hoep.py
+++ b/mynt/parsers/hoep.py
@@ -36,46 +36,46 @@ class _Renderer(h.Hoep):
                 (r'^[^a-z]+', ''),
                 (r'^$', 'section')
             )
-
-
+    
+    
     def block_code(self, text, language):
         text = escape(text)
         language = ' data-lang="{0}"'.format(language) if language else ''
-
+        
         return '<pre><code{0}>{1}</code></pre>'.format(language, text)
-
+    
     def footnotes(self, text):
         return '<div class="footnotes"><ol>{0}</ol></div>'.format(text)
-
+    
     def footnote_def(self, text, number):
         link = '&nbsp;<a href="#fnref{0}" rev="footnote">↩</a>'.format(number)
         index = text.rfind('</p>')
-
+        
         if index:
             text = ''.join((text[:index], link, text[index:]))
         else:
             text = ''.join((text, link))
-
+        
         return '<li id="fn{0}" class="footnotes-def">{1}</li>'.format(number, text)
-
+    
     def footnote_ref(self, number):
         return '<sup id="fnref{0}" class="footnotes-ref"><a href="#fn{0}" rel="footnote">{0}</a></sup>'.format(number)
-
+    
     def header(self, text, hlevel):
         if self.render_flags & h.HTML_TOC:
             identifier = text.lower()
-
+            
             for pattern, replace in self._toc_patterns:
                 identifier = re.sub(pattern, replace, identifier)
-
+            
             if identifier in self._toc_ids:
                 self._toc_ids[identifier] += 1
                 identifier = '{0}-{1}'.format(identifier, self._toc_ids[identifier])
             else:
                 self._toc_ids[identifier] = 1
-
+            
             new_leaf = _TOCLeaf(hlevel, identifier, text)
-
+            
             if hlevel > self._toc_leaf.hlevel:
                 new_leaf.parent = self._toc_leaf
                 new_leaf.level = (self._toc_leaf.level + 1)
@@ -85,27 +85,27 @@ class _Renderer(h.Hoep):
             elif hlevel == self._toc_leaf.hlevel:
                 new_leaf.parent = self._toc_leaf.parent
                 new_leaf.level = self._toc_leaf.level
-
+            
             if new_leaf.parent:
                 new_leaf.parent.children.append(new_leaf)
-
+            
             self._toc_leaf = new_leaf
-
+            
             return '<h{0} id="{1}">{2}</h{0}>'.format(hlevel, identifier, text)
         else:
             return '<h{0}>{1}</h{0}>'.format(hlevel, text)
-
-
+    
+    
     def preprocess(self, markdown):
-
+        
         if self.render_flags & h.HTML_TOC:
             self._toc_ids.clear()
-
+            
             self.toc_tree = _TOCLeaf()
             self._toc_leaf = self.toc_tree
-
+        
         return markdown
-
+    
     def render(self, markdown):
         html = super(_Renderer, self).render(markdown)
         return html if (not self.render_flags & h.HTML_TOC) else (html, self.toc_tree)
@@ -113,8 +113,8 @@ class _Renderer(h.Hoep):
 
 class Parser(_Parser):
     accepts = ('.md', '.markdown')
-
-
+    
+    
     lookup = {
         'extensions': {
             'autolink': h.EXT_AUTOLINK,
@@ -145,7 +145,7 @@ class Parser(_Parser):
             'use_xhtml': h.HTML_USE_XHTML
         }
     }
-
+    
     defaults = {
         'extensions': {
             'autolink': True,
@@ -159,21 +159,21 @@ class Parser(_Parser):
             'smartypants': True
         }
     }
-
-
+    
+    
     def parse(self, markdown):
         return self._md.render(markdown)
-
+    
     def setup(self):
         self.flags = {}
         self.config = deepcopy(self.defaults)
-
+        
         for k, v in self.options.iteritems():
             self.config[k].update(v)
-
+        
         for group, options in self.config.iteritems():
             flags = [self.lookup[group][k] for k, v in options.iteritems() if v]
-
+            
             self.flags[group] = reduce(or_, flags, 0)
-
+        
         self._md = _Renderer(**self.flags)

--- a/mynt/parsers/hoep.py
+++ b/mynt/parsers/hoep.py
@@ -12,71 +12,109 @@ from mynt.base import Parser as _Parser
 from mynt.utils import escape
 
 
+class _TOCLeaf:
+
+    def __init__(self, hlevel = 0, identifier = None, text = None):
+        self.level = 0
+        self.parent = None
+        self.children = []
+        self.hlevel = hlevel
+        self.identifier = identifier
+        self.text = text
+
+
 class _Renderer(h.Hoep):
     def __init__(self, extensions = 0, render_flags = 0):
         super(_Renderer, self).__init__(extensions, render_flags)
-        
-        self._toc_ids = {}
-        self._toc_patterns = (
-            (r'<[^<]+?>', ''),
-            (r'[^a-z0-9_.\s-]', ''),
-            (r'\s+', '-'),
-            (r'^[^a-z]+', ''),
-            (r'^$', 'section')
-        )
-    
-    
+
+        self.has_toc = False
+
+        if self.render_flags & h.HTML_TOC:
+            self._toc_ids = {}
+            self._toc_patterns = (
+                (r'<[^<]+?>', ''),
+                (r'[^a-z0-9_.\s-]', ''),
+                (r'\s+', '-'),
+                (r'^[^a-z]+', ''),
+                (r'^$', 'section')
+            )
+
+
     def block_code(self, text, language):
         text = escape(text)
         language = ' data-lang="{0}"'.format(language) if language else ''
-        
+
         return '<pre><code{0}>{1}</code></pre>'.format(language, text)
-    
+
     def footnotes(self, text):
         return '<div class="footnotes"><ol>{0}</ol></div>'.format(text)
-    
+
     def footnote_def(self, text, number):
         link = '&nbsp;<a href="#fnref{0}" rev="footnote">↩</a>'.format(number)
         index = text.rfind('</p>')
-        
+
         if index:
             text = ''.join((text[:index], link, text[index:]))
         else:
             text = ''.join((text, link))
-        
+
         return '<li id="fn{0}" class="footnotes-def">{1}</li>'.format(number, text)
-    
+
     def footnote_ref(self, number):
         return '<sup id="fnref{0}" class="footnotes-ref"><a href="#fn{0}" rel="footnote">{0}</a></sup>'.format(number)
-    
-    def header(self, text, level):
+
+    def header(self, text, hlevel):
         if self.render_flags & h.HTML_TOC:
             identifier = text.lower()
-            
+
             for pattern, replace in self._toc_patterns:
                 identifier = re.sub(pattern, replace, identifier)
-            
+
             if identifier in self._toc_ids:
                 self._toc_ids[identifier] += 1
                 identifier = '{0}-{1}'.format(identifier, self._toc_ids[identifier])
             else:
                 self._toc_ids[identifier] = 1
-            
-            return '<h{0} id="{1}">{2}</h{0}>'.format(level, identifier, text)
+
+            new_leaf = _TOCLeaf(hlevel, identifier, text)
+
+            if hlevel > self._toc_leaf.hlevel:
+                new_leaf.parent = self._toc_leaf
+                new_leaf.level = (self._toc_leaf.level + 1)
+            elif hlevel < self._toc_leaf.hlevel:
+                new_leaf.parent = self._toc_leaf.parent.parent
+                new_leaf.level = (self._toc_leaf.level - 1)
+            elif hlevel == self._toc_leaf.hlevel:
+                new_leaf.parent = self._toc_leaf.parent
+                new_leaf.level = self._toc_leaf.level
+
+            if new_leaf.parent:
+                new_leaf.parent.children.append(new_leaf)
+
+            self._toc_leaf = new_leaf
+
+            return '<h{0} id="{1}">{2}</h{0}>'.format(hlevel, identifier, text)
         else:
-            return '<h{0}>{1}</h{0}>'.format(level, text)
-    
-    
+            return '<h{0}>{1}</h{0}>'.format(hlevel, text)
+
+
     def preprocess(self, markdown):
-        self._toc_ids.clear()
-        
+
+        self.has_toc = False
+
+        if self.render_flags & h.HTML_TOC:
+            self.toc_tree = _TOCLeaf()
+            self._toc_leaf = self.toc_tree
+            self._toc_ids.clear()
+            self.has_toc = True
+
         return markdown
 
 
 class Parser(_Parser):
     accepts = ('.md', '.markdown')
-    
-    
+
+
     lookup = {
         'extensions': {
             'autolink': h.EXT_AUTOLINK,
@@ -107,7 +145,7 @@ class Parser(_Parser):
             'use_xhtml': h.HTML_USE_XHTML
         }
     }
-    
+
     defaults = {
         'extensions': {
             'autolink': True,
@@ -121,21 +159,26 @@ class Parser(_Parser):
             'smartypants': True
         }
     }
-    
-    
+
+
     def parse(self, markdown):
-        return self._md.render(markdown)
-    
+        result = self._md.render(markdown)
+        self.has_toc = self._md.has_toc
+        if self.has_toc:
+            self.toc_tree = self._md.toc_tree
+        return result
+
     def setup(self):
         self.flags = {}
         self.config = deepcopy(self.defaults)
-        
+        self.has_toc = False
+
         for k, v in self.options.iteritems():
             self.config[k].update(v)
-        
+
         for group, options in self.config.iteritems():
             flags = [self.lookup[group][k] for k, v in options.iteritems() if v]
-            
+
             self.flags[group] = reduce(or_, flags, 0)
-        
+
         self._md = _Renderer(**self.flags)

--- a/mynt/processors.py
+++ b/mynt/processors.py
@@ -149,6 +149,9 @@ class Reader(object):
         text, date = self._parse_filename(f)
         content = parser.parse(self._writer.from_string(bodymatter, frontmatter))
         
+        if parser.has_toc:
+            item['toc'] = parser.toc_tree
+        
         item['content'] = content
         item['date'] = date.strftime(self.site['date_format']).decode('utf-8')
         item['timestamp'] = timegm(date.utctimetuple())

--- a/mynt/processors.py
+++ b/mynt/processors.py
@@ -147,14 +147,17 @@ class Reader(object):
         parser = self._get_parser(f, frontmatter.get('parser', config.get('parser', None)))
         
         text, date = self._parse_filename(f)
-        content = parser.parse(self._writer.from_string(bodymatter, frontmatter))
         
-        if parser.has_toc:
-            item['toc'] = parser.toc_tree
+        result = parser.parse(self._writer.from_string(bodymatter, frontmatter))
+        
+        content, toc = result if isinstance(result, tuple) else (result, None)
         
         item['content'] = content
         item['date'] = date.strftime(self.site['date_format']).decode('utf-8')
         item['timestamp'] = timegm(date.utctimetuple())
+        
+        if toc is not None:
+            item['toc'] = toc
         
         if simple:
             item['url'] = Url.from_path(f.root.path.replace(self.src.path, ''), text)


### PR DESCRIPTION
This generation is completely optional and only works if TOCs are enabled in blog `config.yml`, like this:

```
hoep:
    render_flags:
        toc: true
```

In that case, all posts get an additional attribute, `item.toc`, which is an object that represents a TOC tree, starting from a root (empty) leaf. 
#### Leaf Attributes

Every leaf has these attributes:
- `leaf.hlevel` — the value of `n` from `<Hn>` tag which was used to generate this leaf;
- `leaf.level` — how deep is location of this leaf in a tree, `0` for root;
- `leaf.parent` — parent leaf, `None` for root node;
- `leaf.children` — leaf children, in array;
- `leaf.text` — `<Hn>text</Hn>`, text from inside of a header tag, `None` for root;
- `leaf.identifier` — anchor ID, from `<Hn id="#identifier">text</Hn>`, `None` for root;

If there were no headings found in a post, root leaf has no children (array is empty).
#### Example Macro

Example macro to generate an `UL`-tree from this object (`_templates/macros.html`):

```
{% macro toc(leaf) %}
    {% if leaf %}
        {% if leaf.parent %}
            {# the root leaf has no parent #}
            <li>
                <a href="#{{ leaf.identifier }}" title="{{ leaf.text }}">{{ leaf.text }}</a>
                {% if leaf.children %}
                    <ul>
                        {% for subleaf in leaf.children %}
                            {{ toc(subleaf) }}
                        {% endfor %}
                    </ul>
                {% endif %}
            </li>
        {% else %}
            {# the root leaf should just fall inside #}
            {% for subleaf in leaf.children %}
                {{ toc(subleaf) }}
            {% endfor %}
        {% endif %}
    {% endif %}
{%- endmacro %}
```
#### Example Macro Usage

`_templates/layout.html` or `_templates/post.html`:

```
{% from 'macros.html' import toc as build_toc %}
```

`_templates/post.html`:

```
{% if post.toc %}
    {% block toc %}
        {% if post.toc.children|length > 0 %}
            <nav>
                <h4>Contents:</h4>
                <ul>
                    {{ build_toc(post.toc) }}
                </ul>
            </nav>
        {% endif %}
    {% endblock %}
{% endif %}
```

Cons:
I haven't found a way to return TOC object properly from a parser, so now it returns a tuple from `.render` method in case if TOCs are enabled, very possibly it's not a honest way to do it :).
