### PR TITLE
Omit protocol schema to make URL generation more generic

### DIFF
--- a/mynt/renderers/jinja.py
+++ b/mynt/renderers/jinja.py
@@ -66,8 +66,8 @@ class Renderer(_Renderer):
         domain = self.globals['site']['domain']
         
         if absolute and domain:
-            if not domain.startswith(('http://', 'https://')):
-                domain = 'http://' + domain
+            if not domain.startswith(('http://', 'https://', '//')):
+                domain = '//' + domain
             
             parts.insert(0, domain)
         


### PR DESCRIPTION
This is more generic and doesn't force the user to specify schema (in case one wants to use both https and http for example).