### PR TITLE
Change Atom namespace so feeds validate

### DIFF
--- a/mynt/themes/dark/feed.xml
+++ b/mynt/themes/dark/feed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="https://www.w3.org/2005/Atom">
+<feed xmlns="http://www.w3.org/2005/Atom">
     <title>{{ site.title }}</title>
     {% if site.subtitle %}<subtitle>{{ site.subtitle }}</subtitle>{% endif %}
     <link rel="alternate" href="{{ get_url(absolute=true) }}" />

--- a/mynt/themes/light/feed.xml
+++ b/mynt/themes/light/feed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="https://www.w3.org/2005/Atom">
+<feed xmlns="http://www.w3.org/2005/Atom">
     <title>{{ site.title }}</title>
     {% if site.subtitle %}<subtitle>{{ site.subtitle }}</subtitle>{% endif %}
     <link rel="alternate" href="{{ get_url(absolute=true) }}" />


### PR DESCRIPTION
In Atom, XML namespace on HTTP protocol must be used.
https://validator.w3.org/feed/docs/error/InvalidNamespace.html

Because HTTPS protocol was used, generated feeds failed validation.

Great piece of software by the way! :D